### PR TITLE
경북대 FE 최지원 - 1단계 React Query 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@hookform/resolvers": "^5.1.1",
+        "@tanstack/react-query": "^5.83.0",
         "axios": "^1.10.0",
         "emotion-reset": "^3.0.1",
         "react": "^19.1.0",
@@ -1560,6 +1561,32 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.1.1",
+    "@tanstack/react-query": "^5.83.0",
     "axios": "^1.10.0",
     "emotion-reset": "^3.0.1",
     "react": "^19.1.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,37 +12,50 @@ import OrderPage from "./pages/OrderPage";
 import ThemeProduct from "./pages/ThemeProduct";
 import { PATH } from "@/constants/path";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { Spinner } from "@/components/common/Spinner";
+import ErrorBoundary from "@/components/common/ErrorBoundary";
+
+const queryClient = new QueryClient();
+
 const App = () => {
   return (
     <ThemeProvider theme={theme}>
       <Global styles={GlobalResetStyle} />
-      <BrowserRouter>
+      <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <Routes>
-            <Route path={PATH.HOME} element={<GiftMain />} />
-            <Route path={PATH.LOGIN} element={<Login />} />
-            <Route
-              path={PATH.MY_PAGE}
-              element={
-                <RequireAuth>
-                  <MyPage />
-                </RequireAuth>
-              }
-            />
-            <Route
-              path={PATH.ORDER()}
-              element={
-                <RequireAuth>
-                  <OrderPage />
-                </RequireAuth>
-              }
-            />
-            <Route path={PATH.THEME()} element={<ThemeProduct />} />
-            <Route path={PATH.NOT_FOUND} element={<NotFound />} />
-            <Route path={PATH.ALL} element={<NotFound />} />
-          </Routes>
+          <ErrorBoundary>
+            <Suspense fallback={<Spinner size={48} withWrapper />}>
+              <BrowserRouter>
+                <Routes>
+                  <Route path={PATH.HOME} element={<GiftMain />} />
+                  <Route path={PATH.LOGIN} element={<Login />} />
+                  <Route
+                    path={PATH.MY_PAGE}
+                    element={
+                      <RequireAuth>
+                        <MyPage />
+                      </RequireAuth>
+                    }
+                  />
+                  <Route
+                    path={PATH.ORDER()}
+                    element={
+                      <RequireAuth>
+                        <OrderPage />
+                      </RequireAuth>
+                    }
+                  />
+                  <Route path={PATH.THEME()} element={<ThemeProduct />} />
+                  <Route path={PATH.NOT_FOUND} element={<NotFound />} />
+                  <Route path={PATH.ALL} element={<NotFound />} />
+                </Routes>
+              </BrowserRouter>
+            </Suspense>
+          </ErrorBoundary>
         </AuthProvider>
-      </BrowserRouter>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,47 +13,43 @@ import ThemeProduct from "./pages/ThemeProduct";
 import { PATH } from "@/constants/path";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Suspense } from "react";
-import { Spinner } from "@/components/common/Spinner";
-import ErrorBoundary from "@/components/common/ErrorBoundary";
+import AsyncBoundary from "@/components/common/AsyncBoundary";
 
 const queryClient = new QueryClient();
 
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter> 
+      <BrowserRouter>
         <ThemeProvider theme={theme}>
           <Global styles={GlobalResetStyle} />
-          <AuthProvider>
-            <ErrorBoundary>
-              <Suspense fallback={<Spinner size={48} withWrapper />}>
-                <Routes>
-                  <Route path={PATH.HOME} element={<GiftMain />} />
-                  <Route path={PATH.LOGIN} element={<Login />} />
-                  <Route
-                    path={PATH.MY_PAGE}
-                    element={
-                      <RequireAuth>
-                        <MyPage />
-                      </RequireAuth>
-                    }
-                  />
-                  <Route
-                    path={PATH.ORDER()}
-                    element={
-                      <RequireAuth>
-                        <OrderPage />
-                      </RequireAuth>
-                    }
-                  />
-                  <Route path={PATH.THEME()} element={<ThemeProduct />} />
-                  <Route path={PATH.NOT_FOUND} element={<NotFound />} />
-                  <Route path={PATH.ALL} element={<NotFound />} />
-                </Routes>
-              </Suspense>
-            </ErrorBoundary>
-          </AuthProvider>
+          <AsyncBoundary>
+            <AuthProvider>
+              <Routes>
+                <Route path={PATH.HOME} element={<GiftMain />} />
+                <Route path={PATH.LOGIN} element={<Login />} />
+                <Route
+                  path={PATH.MY_PAGE}
+                  element={
+                    <RequireAuth>
+                      <MyPage />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path={PATH.ORDER()}
+                  element={
+                    <RequireAuth>
+                      <OrderPage />
+                    </RequireAuth>
+                  }
+                />
+                <Route path={PATH.THEME()} element={<ThemeProduct />} />
+                <Route path={PATH.NOT_FOUND} element={<NotFound />} />
+                <Route path={PATH.ALL} element={<NotFound />} />
+              </Routes>
+            </AuthProvider>
+          </AsyncBoundary>
         </ThemeProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,13 +21,13 @@ const queryClient = new QueryClient();
 
 const App = () => {
   return (
-    <ThemeProvider theme={theme}>
-      <Global styles={GlobalResetStyle} />
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <ErrorBoundary>
-            <Suspense fallback={<Spinner size={48} withWrapper />}>
-              <BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter> 
+        <ThemeProvider theme={theme}>
+          <Global styles={GlobalResetStyle} />
+          <AuthProvider>
+            <ErrorBoundary>
+              <Suspense fallback={<Spinner size={48} withWrapper />}>
                 <Routes>
                   <Route path={PATH.HOME} element={<GiftMain />} />
                   <Route path={PATH.LOGIN} element={<Login />} />
@@ -51,12 +51,12 @@ const App = () => {
                   <Route path={PATH.NOT_FOUND} element={<NotFound />} />
                   <Route path={PATH.ALL} element={<NotFound />} />
                 </Routes>
-              </BrowserRouter>
-            </Suspense>
-          </ErrorBoundary>
-        </AuthProvider>
-      </QueryClientProvider>
-    </ThemeProvider>
+              </Suspense>
+            </ErrorBoundary>
+          </AuthProvider>
+        </ThemeProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
   );
 };
 

--- a/src/components/category/CategorySection.tsx
+++ b/src/components/category/CategorySection.tsx
@@ -1,40 +1,14 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useState, useCallback } from "react";
 import styled from "@emotion/styled";
 
-import { fetchThemes } from "@/api/theme";
-import type { Theme } from "@/api/theme";
 import { CategoryCard } from "@/components/category/CategoryCard";
-import { Spinner } from "@/components/common/Spinner";
+import { useThemes } from "@/hooks/queries/useThemes";
 
 export const CategorySection = () => {
-  const [themes, setThemes] = useState<Theme[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const { data: themes } = useThemes();
 
-  const fetchThemesData = useCallback(async () => {
-    try {
-      setLoading(true);
-      const data = await fetchThemes();
-      setThemes(data);
-      setError(false);
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    fetchThemesData();
-  }, [fetchThemesData]);
-
-  if (loading) {
-    return <Spinner size={48} withWrapper />;
-  }
-
-  if (error || themes.length === 0) {
-    return <ErrorBanner>해당 ID에 일치하는 데이터가 없습니다.</ErrorBanner>;
+  if (!themes || themes.length === 0) {
+    return <ErrorBanner>카테고리를 불러올 수 없습니다.</ErrorBanner>;
   }
 
   return (

--- a/src/components/category/CategorySection.tsx
+++ b/src/components/category/CategorySection.tsx
@@ -7,8 +7,12 @@ import { useThemes } from "@/hooks/queries/useThemes";
 export const CategorySection = () => {
   const { data: themes } = useThemes();
 
-  if (!themes || themes.length === 0) {
+  if (!themes) {
     return <ErrorBanner>카테고리를 불러올 수 없습니다.</ErrorBanner>;
+  }
+
+  if (themes.length === 0) {
+    return <p>표시할 카테고리가 없습니다.</p>;
   }
 
   return (

--- a/src/components/common/AsyncBoundary.tsx
+++ b/src/components/common/AsyncBoundary.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+import ErrorBoundary from "./ErrorBoundary";
+import { Spinner } from "./Spinner";
+
+const AsyncBoundary = ({ children }: { children: React.ReactNode }) => (
+  <Suspense fallback={<Spinner size={48} withWrapper />}>
+    <ErrorBoundary>{children}</ErrorBoundary>
+  </Suspense>
+);
+
+export default AsyncBoundary;

--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component} from "react";
+import type {ReactNode} from "react";
+
+type Props = {
+  children: ReactNode;
+  fallback?: ReactNode;
+};
+
+type State = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <p>문제가 발생했습니다. 다시 시도해주세요.</p>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -7,12 +7,13 @@ import {
   ErrorMessage,
   LoginButton,
 } from "./LoginFormStyles";
-import { postLogin } from "@/api/auth";
-import { userStorage } from "@/utils/userStorage";
 import { toast } from "react-toastify";
 
+import { useLogin } from "@/hooks/mutations/useLogin";
+import { userStorage } from "@/utils/userStorage";
+
 type Props = {
-  onLoginSuccess: (email: string, token: string) => void; 
+  onLoginSuccess: (email: string, token: string) => void;
 };
 
 export const LoginForm = ({ onLoginSuccess }: Props) => {
@@ -55,7 +56,21 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
     if (name === "password") setPasswordError(validatePassword(value));
   };
 
-  const handleSubmit = async () => {
+  const { mutate: loginMutate, isPending } = useLogin(
+    (data) => {
+      userStorage.set(data);
+      toast.success("로그인 성공!");
+      onLoginSuccess(data.email, data.authToken);
+    },
+    (msg) => {
+      toast.error(msg);
+    }
+  );
+
+  const isDisabled =
+    !email || !password || !!emailError || !!passwordError || isPending;
+
+  const handleSubmit = () => {
     const emailErr = getValidateEmail(email);
     const pwErr = validatePassword(password);
     setEmailError(emailErr);
@@ -68,20 +83,8 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
       return;
     }
 
-    try {
-      const data = await postLogin({ email, password });
-      userStorage.set(data);
-      toast.success("로그인 성공!");
-
-      onLoginSuccess(data.email, data.authToken);
-    } catch (err: any) {
-      const message =
-        err?.response?.data?.data?.message || "로그인에 실패했습니다.";
-      toast.error(message);
-    }
+    loginMutate({ email, password });
   };
-
-  const disabled = !email || !password || !!emailError || !!passwordError;
 
   return (
     <FormSection>
@@ -111,8 +114,8 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
         {passwordError && <ErrorMessage>{passwordError}</ErrorMessage>}
       </InputWrapper>
 
-      <LoginButton onClick={handleSubmit} disabled={disabled}>
-        로그인
+      <LoginButton onClick={handleSubmit} disabled={isDisabled}>
+        {isPending ? "로그인 중..." : "로그인"}
       </LoginButton>
     </FormSection>
   );

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,4 +1,3 @@
-/** @jsxImportSource @emotion/react */
 import { useState } from "react";
 import {
   FormSection,
@@ -7,10 +6,9 @@ import {
   ErrorMessage,
   LoginButton,
 } from "./LoginFormStyles";
-import { toast } from "react-toastify";
-
-import { useLogin } from "@/hooks/mutations/useLogin";
 import { userStorage } from "@/utils/userStorage";
+import { toast } from "react-toastify";
+import { useLogin } from "@/hooks/mutations/useLogin";
 
 type Props = {
   onLoginSuccess: (email: string, token: string) => void;
@@ -29,15 +27,26 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
     return "";
   };
 
-  const isKakaoEmail = (email: string) => {
-    return email.endsWith("@kakao.com");
-  };
-
   const validatePassword = (password: string) => {
     if (!password) return "PW를 입력해주세요.";
     if (password.length < 8) return "PW는 최소 8글자 이상이어야 합니다.";
     return "";
   };
+
+  const isKakaoEmail = (email: string) => {
+    return email.endsWith("@kakao.com");
+  };
+
+  const { mutate: loginMutate, isPending } = useLogin({
+    onSuccess: (data) => {
+      userStorage.set(data);
+      toast.success("로그인 성공!");
+      onLoginSuccess(data.email, data.authToken);
+    },
+    onError: (msg) => {
+      toast.error(msg);
+    },
+  });
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -56,26 +65,11 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
     if (name === "password") setPasswordError(validatePassword(value));
   };
 
-  const { mutate: loginMutate, isPending } = useLogin(
-    (data) => {
-      userStorage.set(data);
-      toast.success("로그인 성공!");
-      onLoginSuccess(data.email, data.authToken);
-    },
-    (msg) => {
-      toast.error(msg);
-    }
-  );
-
-  const isDisabled =
-    !email || !password || !!emailError || !!passwordError || isPending;
-
   const handleSubmit = () => {
     const emailErr = getValidateEmail(email);
     const pwErr = validatePassword(password);
     setEmailError(emailErr);
     setPasswordError(pwErr);
-
     if (emailErr || pwErr) return;
 
     if (!isKakaoEmail(email)) {
@@ -85,6 +79,8 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
 
     loginMutate({ email, password });
   };
+
+  const disabled = !email || !password || !!emailError || !!passwordError || isPending;
 
   return (
     <FormSection>
@@ -114,8 +110,8 @@ export const LoginForm = ({ onLoginSuccess }: Props) => {
         {passwordError && <ErrorMessage>{passwordError}</ErrorMessage>}
       </InputWrapper>
 
-      <LoginButton onClick={handleSubmit} disabled={isDisabled}>
-        {isPending ? "로그인 중..." : "로그인"}
+      <LoginButton onClick={handleSubmit} disabled={disabled}>
+        로그인
       </LoginButton>
     </FormSection>
   );

--- a/src/components/ranking/RankingSection.tsx
+++ b/src/components/ranking/RankingSection.tsx
@@ -1,13 +1,11 @@
 /** @jsxImportSource @emotion/react */
-import { useEffect, useMemo, useState, useCallback } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useTheme } from "@emotion/react";
 
 import * as S from "./RankingSection.styles";
 import { RankingCard } from "./RankingCard";
-import { fetchRanking } from "@/api/ranking";
-import type { RankingItem, RankType, TargetType } from "@/api/ranking";
-import { Spinner } from "@/components/common/Spinner";
+import { useRanking } from "@/hooks/queries/useRanking";
+import type { RankType, TargetType } from "@/api/ranking";
 
 const GROUP_PARAM = "group";
 const ACTION_PARAM = "action";
@@ -28,71 +26,21 @@ const actionOptions: { key: RankType; label: string }[] = [
 
 export const RankingSection = () => {
   const theme = useTheme();
-  const [isExpanded, setIsExpanded] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
 
   const group = (searchParams.get(GROUP_PARAM) || "ALL") as TargetType;
   const action = (searchParams.get(ACTION_PARAM) || "MANY_WISH") as RankType;
 
-  const [data, setData] = useState<RankingItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const { data: rankingList = [] } = useRanking({ targetType: group, rankType: action });
+  const isExpanded = rankingList.length > ITEM_COUNT;
 
-  const updateParam = useCallback(
-    (key: string, value: string) => {
-      const newParams = new URLSearchParams(searchParams);
-      newParams.set(key, value);
-      setSearchParams(newParams);
-    },
-    [searchParams, setSearchParams]
-  );
-
-  const visibleItems = useMemo(() => {
-    return isExpanded ? data : data.slice(0, ITEM_COUNT);
-  }, [isExpanded, data]);
-
-  const fetchRankingData = async () => {
-    try {
-      setLoading(true);
-      const result = await fetchRanking({ targetType: group, rankType: action });
-      setData(result);
-      setError(false);
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
+  const updateParam = (key: string, value: string) => {
+    const newParams = new URLSearchParams(searchParams);
+    newParams.set(key, value);
+    setSearchParams(newParams);
   };
 
-  useEffect(() => {
-    fetchRankingData();
-  }, [group, action]);
-
-  const renderContent = () => {
-    if (loading) {
-    return <Spinner size={48} withWrapper />;
-  }
-
-    if (error || data.length === 0) {
-      return <EmptyState>상품이 없습니다.</EmptyState>;
-    }
-
-    return (
-      <div css={S.grid(theme)}>
-        {visibleItems.map((item, idx) => (
-          <RankingCard
-            key={item.id}
-            rank={idx + 1}
-            id={item.id}
-            imageURL={item.imageURL}
-            brandName={item.brandInfo.name}
-            productName={item.name}
-            price={item.price.sellingPrice}
-          />
-        ))}
-      </div>
-    );
-  };
+  const visibleItems = isExpanded ? rankingList.slice(0, ITEM_COUNT) : rankingList;
 
   return (
     <section css={S.section(theme)}>
@@ -125,12 +73,22 @@ export const RankingSection = () => {
         </div>
       </div>
 
-      {renderContent()}
-
-      {!loading && data.length > ITEM_COUNT && (
-        <button css={S.moreButton(theme)} onClick={() => setIsExpanded((prev) => !prev)}>
-          <p>{isExpanded ? "접기" : "더보기"}</p>
-        </button>
+      {rankingList.length === 0 ? (
+        <EmptyState>상품이 없습니다.</EmptyState>
+      ) : (
+        <div css={S.grid(theme)}>
+          {visibleItems.map((item, idx) => (
+            <RankingCard
+              key={item.id}
+              rank={idx + 1}
+              id={item.id}
+              imageURL={item.imageURL}
+              brandName={item.brandInfo.name}
+              productName={item.name}
+              price={item.price.sellingPrice}
+            />
+          ))}
+        </div>
       )}
     </section>
   );

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,3 @@
+export const QUERY_KEYS = {
+  productSummary: (productId: number) => ["productSummary", productId] as const,
+};

--- a/src/hooks/mutations/useCreateOrder.ts
+++ b/src/hooks/mutations/useCreateOrder.ts
@@ -1,35 +1,15 @@
 import { useMutation } from "@tanstack/react-query";
 import { postCreateOrder } from "@/api/orderapi";
 import type { OrderFormValues } from "@/validations/orderSchema";
-import type { AxiosResponse } from "axios";
-
-interface UseCreateOrderProps {
-  productId: number;
-  token: string;
-  onSuccess?: (
-    data: AxiosResponse<{ data: { success: boolean } }>,
-    variables: OrderFormValues
-  ) => void;
-  onError?: (message: string) => void;
-}
 
 export const useCreateOrder = ({
   productId,
   token,
-  onSuccess,
-  onError,
-}: UseCreateOrderProps) => {
+}: {
+  productId: number;
+  token: string;
+}) => {
   return useMutation({
-    mutationFn: (data: OrderFormValues) =>
-      postCreateOrder(data, productId, token),
-    onSuccess: (data, variables) => {
-      onSuccess?.(data, variables);
-    },
-    onError: (error: any) => {
-      const msg =
-        error?.response?.data?.data?.message ||
-        "주문 요청 중 오류가 발생했습니다.";
-      onError?.(msg);
-    },
+    mutationFn: (data: OrderFormValues) => postCreateOrder(data, productId, token),
   });
 };

--- a/src/hooks/mutations/useCreateOrder.ts
+++ b/src/hooks/mutations/useCreateOrder.ts
@@ -1,0 +1,35 @@
+import { useMutation } from "@tanstack/react-query";
+import { postCreateOrder } from "@/api/orderapi";
+import type { OrderFormValues } from "@/validations/orderSchema";
+import type { AxiosResponse } from "axios";
+
+interface UseCreateOrderProps {
+  productId: number;
+  token: string;
+  onSuccess?: (
+    data: AxiosResponse<{ data: { success: boolean } }>,
+    variables: OrderFormValues
+  ) => void;
+  onError?: (message: string) => void;
+}
+
+export const useCreateOrder = ({
+  productId,
+  token,
+  onSuccess,
+  onError,
+}: UseCreateOrderProps) => {
+  return useMutation({
+    mutationFn: (data: OrderFormValues) =>
+      postCreateOrder(data, productId, token),
+    onSuccess: (data, variables) => {
+      onSuccess?.(data, variables);
+    },
+    onError: (error: any) => {
+      const msg =
+        error?.response?.data?.data?.message ||
+        "주문 요청 중 오류가 발생했습니다.";
+      onError?.(msg);
+    },
+  });
+};

--- a/src/hooks/mutations/useLogin.ts
+++ b/src/hooks/mutations/useLogin.ts
@@ -3,17 +3,21 @@ import { postLogin } from "@/api/auth";
 import type { LoginRequest, LoginResponse } from "@/api/auth";
 
 
-export const useLogin = (
-  onSuccess: (data: LoginResponse) => void,
-  onError: (message: string) => void
-) => {
+interface UseLoginOptions {
+  onSuccess: (data: LoginResponse) => void;
+  onError: (message: string) => void;
+}
+
+export const useLogin = ({ onSuccess, onError }: UseLoginOptions) => {
   return useMutation({
-    mutationFn: (form: LoginRequest) => postLogin(form),
-    onSuccess,
-    onError: (error: any) => {
-      const msg =
-        error?.response?.data?.data?.message || "로그인 중 오류가 발생했습니다.";
-      onError(msg);
+    mutationFn: (body: LoginRequest) => postLogin(body),
+    onSuccess: (data) => {
+      onSuccess(data);
+    },
+    onError: (err: any) => {
+      const message =
+        err?.response?.data?.data?.message || "로그인에 실패했습니다.";
+      onError(message);
     },
   });
 };

--- a/src/hooks/mutations/useLogin.ts
+++ b/src/hooks/mutations/useLogin.ts
@@ -1,0 +1,19 @@
+import { useMutation } from "@tanstack/react-query";
+import { postLogin } from "@/api/auth";
+import type { LoginRequest, LoginResponse } from "@/api/auth";
+
+
+export const useLogin = (
+  onSuccess: (data: LoginResponse) => void,
+  onError: (message: string) => void
+) => {
+  return useMutation({
+    mutationFn: (form: LoginRequest) => postLogin(form),
+    onSuccess,
+    onError: (error: any) => {
+      const msg =
+        error?.response?.data?.data?.message || "로그인 중 오류가 발생했습니다.";
+      onError(msg);
+    },
+  });
+};

--- a/src/hooks/queries/useProductSummary.ts
+++ b/src/hooks/queries/useProductSummary.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { getProductSummary } from "@/api/product";
+import type { ProductSummary } from "@/api/product";
+
+export const useProductSummary = (productId: number) => {
+  return useQuery<ProductSummary, Error>({
+    queryKey: ["productSummary", productId],
+    queryFn: () => getProductSummary(productId),
+    enabled: !!productId,
+  });
+};

--- a/src/hooks/queries/useProductSummary.ts
+++ b/src/hooks/queries/useProductSummary.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getProductSummary } from "@/api/product";
 import type { ProductSummary } from "@/api/product";
+import { QUERY_KEYS } from "@/constants/queryKeys";
 
 export const useProductSummary = (productId: number) => {
   return useQuery<ProductSummary, Error>({
-    queryKey: ["productSummary", productId],
+    queryKey: QUERY_KEYS.productSummary(productId),
     queryFn: () => getProductSummary(productId),
-    enabled: !!productId,
   });
 };

--- a/src/hooks/queries/useRanking.ts
+++ b/src/hooks/queries/useRanking.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchRanking } from "@/api/ranking";
+import type { RankType, TargetType, RankingItem } from "@/api/ranking";
+
+interface UseRankingParams {
+  targetType: TargetType;
+  rankType: RankType;
+}
+
+export const useRanking = ({ targetType, rankType }: UseRankingParams) => {
+  return useQuery<RankingItem[], Error>({
+    queryKey: ["ranking", targetType, rankType],
+    queryFn: () => fetchRanking({ targetType, rankType }),
+  });
+};

--- a/src/hooks/queries/useThemes.ts
+++ b/src/hooks/queries/useThemes.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchThemes } from '@/api/theme';
+import type { Theme } from '@/api/theme';
+
+export const useThemes = () => {
+  return useQuery<Theme[], Error>({
+    queryKey: ['themes'],
+    queryFn: fetchThemes,
+  });
+};

--- a/src/pages/GiftMain.tsx
+++ b/src/pages/GiftMain.tsx
@@ -17,7 +17,9 @@ const GiftMain = () => {
           <CategorySection />
         </AsyncBoundary>
         <MessageBanner />
-        <RankingSection />
+        <AsyncBoundary>
+          <RankingSection />
+        </AsyncBoundary>
       </PageContainer>
     </PageLayout>
   );

--- a/src/pages/GiftMain.tsx
+++ b/src/pages/GiftMain.tsx
@@ -5,9 +5,7 @@ import { CategorySection } from "@/components/category/CategorySection";
 import { FriendBanner } from "@/components/banner/FriendBanner";
 import { MessageBanner } from "@/components/banner/MessageBanner";
 import { RankingSection } from "@/components/ranking/RankingSection";
-import { Suspense } from "react";
-import { Spinner } from "@/components/common/Spinner";
-import ErrorBoundary from "@/components/common/ErrorBoundary";
+import AsyncBoundary from "@/components/common/AsyncBoundary";
 
 const GiftMain = () => {
   return (
@@ -15,11 +13,9 @@ const GiftMain = () => {
       <PageContainer>
         <Navigation />
         <FriendBanner />
-        <Suspense fallback={<Spinner size={48} withWrapper />}>
-          <ErrorBoundary>
-            <CategorySection />
-          </ErrorBoundary>
-        </Suspense>
+        <AsyncBoundary>
+          <CategorySection />
+        </AsyncBoundary>
         <MessageBanner />
         <RankingSection />
       </PageContainer>

--- a/src/pages/GiftMain.tsx
+++ b/src/pages/GiftMain.tsx
@@ -5,6 +5,9 @@ import { CategorySection } from "@/components/category/CategorySection";
 import { FriendBanner } from "@/components/banner/FriendBanner";
 import { MessageBanner } from "@/components/banner/MessageBanner";
 import { RankingSection } from "@/components/ranking/RankingSection";
+import { Suspense } from "react";
+import { Spinner } from "@/components/common/Spinner";
+import ErrorBoundary from "@/components/common/ErrorBoundary";
 
 const GiftMain = () => {
   return (
@@ -12,7 +15,11 @@ const GiftMain = () => {
       <PageContainer>
         <Navigation />
         <FriendBanner />
-        <CategorySection />
+        <Suspense fallback={<Spinner size={48} withWrapper />}>
+          <ErrorBoundary>
+            <CategorySection />
+          </ErrorBoundary>
+        </Suspense>
         <MessageBanner />
         <RankingSection />
       </PageContainer>

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import * as S from "@/styles/OrderPageStyles";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useForm, FormProvider } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -8,6 +8,7 @@ import { toast } from "react-toastify";
 
 import { orderFormSchema } from "@/validations/orderSchema";
 import type { OrderFormValues } from "@/validations/orderSchema";
+
 import { PageLayout } from "@/components/layout/PageLayout";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Navigation } from "@/components/header/Navigation";
@@ -18,26 +19,22 @@ import ReceiverTable from "@/components/order/ReceiverTable";
 import OrderSummary from "@/components/order/OrderSummary";
 import OrderButton from "@/components/order/OrderButton";
 
-import { getProductSummary } from "@/api/product";
-import type { ProductSummary } from "@/api/product";
 import { postCreateOrder } from "@/api/orderapi";
 import { useAuth } from "@/contexts/AuthContext";
 import { PATH } from "@/constants/path";
 import { messageCards } from "@/mock/messageCards";
 
+import { useProductSummary } from "@/hooks/queries/useProductSummary";
+
 const OrderPage = () => {
   const navigate = useNavigate();
   const { id } = useParams();
-  const [product, setProduct] = useState<ProductSummary | null>(null);
-  const [isReceiverModalOpen, setReceiverModalOpen] = useState(false);
-
   const { token, isInitialized, isLoggedIn, user } = useAuth();
-  if (!isInitialized) return null;
 
-  if (!isLoggedIn) {
-    navigate(PATH.LOGIN, { replace: true });
-    return null;
-  }
+  const productId = Number(id);
+  const { data: product } = useProductSummary(productId);
+
+  const [isReceiverModalOpen, setReceiverModalOpen] = useState(false);
 
   const methods = useForm<OrderFormValues>({
     resolver: zodResolver(orderFormSchema),
@@ -49,20 +46,22 @@ const OrderPage = () => {
     },
     mode: "onBlur",
   });
+
   useEffect(() => {
     const defaultCard = messageCards.find(
-      c => c.id === Number(methods.getValues("selectedCardId")),
+      c => c.id === Number(methods.getValues("selectedCardId"))
     );
     if (defaultCard) {
       methods.setValue("message", defaultCard.defaultTextMessage);
     }
   }, [methods]);
+
   const { handleSubmit, watch, setValue } = methods;
   const receivers = watch("receivers") ?? [];
 
   const totalQuantity = receivers.reduce(
     (sum, r) => sum + (r.quantity ?? 0),
-    0,
+    0
   );
   const totalAmount = (product?.price.sellingPrice ?? 0) * totalQuantity;
 
@@ -71,63 +70,27 @@ const OrderPage = () => {
   };
 
   const onValid = async (data: OrderFormValues) => {
-  if (!product) return;
+    if (!product) return;
 
-  if (!token) {
-    toast.error("로그인이 필요합니다.");
-    navigate(PATH.LOGIN, { replace: true });
-    return;
-  }
-
-  try {
-    await postCreateOrder(data, product.id, token);
-    methods.reset();
-
-    const totalQuantity = data.receivers.reduce((sum, r) => sum + r.quantity, 0);
-
-    const confirmed = window.confirm(
-      `주문이 완료되었습니다.\n` +
-      `상품명: ${product.name}\n` +
-      `구매 수량: ${totalQuantity}\n` +
-      `받는 사람: ${data.receivers[0]?.name}\n` +
-      `메시지: ${data.message}`
-    );
-
-    if (confirmed) {
-      navigate(PATH.HOME, { replace: true });
-    }
-  } catch (err: any) {
-    const msg =
-      err?.response?.data?.data?.message ||
-      "주문 요청 중 오류가 발생했습니다.";
-    toast.error(msg);
-  }
-};
-
-
-  const fetchProduct = useCallback(async () => {
-    if (!id || isNaN(Number(id))) {
-      toast.error("잘못된 상품 ID입니다.");
-      navigate(PATH.NOT_FOUND, { replace: true });
+    if (!token) {
+      toast.error("로그인이 필요합니다.");
+      navigate(PATH.LOGIN, { replace: true });
       return;
     }
 
     try {
-      const data = await getProductSummary(Number(id));
-      setProduct(data);
+      await postCreateOrder(data, product.id, token);
+      toast.success("주문이 성공적으로 완료되었습니다!");
+      navigate(PATH.HOME, { replace: true });
     } catch (err: any) {
       const msg =
         err?.response?.data?.data?.message ||
-        "상품 정보를 불러오지 못했습니다.";
+        "주문 요청 중 오류가 발생했습니다.";
       toast.error(msg);
-      navigate(PATH.NOT_FOUND, { replace: true });
     }
-  }, [id, navigate]);
+  };
 
-  useEffect(() => {
-    fetchProduct();
-  }, [fetchProduct]);
-
+  if (!isInitialized || !isLoggedIn) return null;
   if (!product) return null;
 
   return (

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -8,7 +8,7 @@ import { toast } from "react-toastify";
 
 import { orderFormSchema } from "@/validations/orderSchema";
 import type { OrderFormValues } from "@/validations/orderSchema";
-
+import type { AxiosError } from "axios";
 import { PageLayout } from "@/components/layout/PageLayout";
 import { PageContainer } from "@/components/layout/PageContainer";
 import { Navigation } from "@/components/header/Navigation";
@@ -68,32 +68,9 @@ const OrderPage = () => {
     setValue("receivers", data);
   };
 
-  const { mutate: createOrder } = useCreateOrder({
+  const { mutate } = useCreateOrder({
     productId: product?.id ?? 0,
     token: token ?? "",
-    onSuccess: (_response, variables) => {
-      methods.reset();
-
-      const totalQuantity = variables.receivers.reduce(
-        (sum, r) => sum + r.quantity,
-        0,
-      );
-
-      const confirmed = window.confirm(
-        `🎉 주문이 완료되었습니다.\n\n` +
-          `상품명: ${product?.name}\n` +
-          `구매 수량: ${totalQuantity}\n` +
-          `받는 사람: ${variables.receivers[0]?.name}\n` +
-          `메시지: ${variables.message}\n\n`,
-      );
-
-      if (confirmed) {
-        navigate(PATH.HOME, { replace: true });
-      }
-    },
-    onError: msg => {
-      toast.error(msg);
-    },
   });
 
   const onValid = (data: OrderFormValues) => {
@@ -105,7 +82,40 @@ const OrderPage = () => {
       return;
     }
 
-    createOrder(data);
+    mutate(data, {
+      onSuccess: (_response, variables) => {
+        methods.reset();
+
+        const totalQuantity = variables.receivers.reduce(
+          (sum, r) => sum + r.quantity,
+          0,
+        );
+
+        const confirmed = window.confirm(
+          `🎉 주문이 완료되었습니다.\n\n` +
+            `상품명: ${product.name}\n` +
+            `구매 수량: ${totalQuantity}\n` +
+            `받는 사람: ${variables.receivers[0]?.name}\n` +
+            `메시지: ${variables.message}\n\n`,
+        );
+
+        if (confirmed) {
+          navigate(PATH.HOME, { replace: true });
+        }
+      },
+      onError: err => {
+        const axiosError = err as AxiosError<{
+          data: { message: string };
+        }>;
+
+        const msg =
+          axiosError.response?.data?.data?.message ||
+          axiosError.message ||
+          "주문 요청 중 오류가 발생했습니다.";
+
+        toast.error(msg);
+      },
+    });
   };
 
   if (!isInitialized || !isLoggedIn) return null;

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -19,12 +19,12 @@ import ReceiverTable from "@/components/order/ReceiverTable";
 import OrderSummary from "@/components/order/OrderSummary";
 import OrderButton from "@/components/order/OrderButton";
 
-import { postCreateOrder } from "@/api/orderapi";
 import { useAuth } from "@/contexts/AuthContext";
 import { PATH } from "@/constants/path";
 import { messageCards } from "@/mock/messageCards";
 
 import { useProductSummary } from "@/hooks/queries/useProductSummary";
+import { useCreateOrder } from "@/hooks/mutations/useCreateOrder";
 
 const OrderPage = () => {
   const navigate = useNavigate();
@@ -33,7 +33,6 @@ const OrderPage = () => {
 
   const productId = Number(id);
   const { data: product } = useProductSummary(productId);
-
   const [isReceiverModalOpen, setReceiverModalOpen] = useState(false);
 
   const methods = useForm<OrderFormValues>({
@@ -49,7 +48,7 @@ const OrderPage = () => {
 
   useEffect(() => {
     const defaultCard = messageCards.find(
-      c => c.id === Number(methods.getValues("selectedCardId"))
+      c => c.id === Number(methods.getValues("selectedCardId")),
     );
     if (defaultCard) {
       methods.setValue("message", defaultCard.defaultTextMessage);
@@ -61,7 +60,7 @@ const OrderPage = () => {
 
   const totalQuantity = receivers.reduce(
     (sum, r) => sum + (r.quantity ?? 0),
-    0
+    0,
   );
   const totalAmount = (product?.price.sellingPrice ?? 0) * totalQuantity;
 
@@ -69,7 +68,35 @@ const OrderPage = () => {
     setValue("receivers", data);
   };
 
-  const onValid = async (data: OrderFormValues) => {
+  const { mutate: createOrder } = useCreateOrder({
+    productId: product?.id ?? 0,
+    token: token ?? "",
+    onSuccess: (_response, variables) => {
+      methods.reset();
+
+      const totalQuantity = variables.receivers.reduce(
+        (sum, r) => sum + r.quantity,
+        0,
+      );
+
+      const confirmed = window.confirm(
+        `🎉 주문이 완료되었습니다.\n\n` +
+          `상품명: ${product?.name}\n` +
+          `구매 수량: ${totalQuantity}\n` +
+          `받는 사람: ${variables.receivers[0]?.name}\n` +
+          `메시지: ${variables.message}\n\n`,
+      );
+
+      if (confirmed) {
+        navigate(PATH.HOME, { replace: true });
+      }
+    },
+    onError: msg => {
+      toast.error(msg);
+    },
+  });
+
+  const onValid = (data: OrderFormValues) => {
     if (!product) return;
 
     if (!token) {
@@ -78,16 +105,7 @@ const OrderPage = () => {
       return;
     }
 
-    try {
-      await postCreateOrder(data, product.id, token);
-      toast.success("주문이 성공적으로 완료되었습니다!");
-      navigate(PATH.HOME, { replace: true });
-    } catch (err: any) {
-      const msg =
-        err?.response?.data?.data?.message ||
-        "주문 요청 중 오류가 발생했습니다.";
-      toast.error(msg);
-    }
+    createOrder(data);
   };
 
   if (!isInitialized || !isLoggedIn) return null;

--- a/src/pages/ThemeProduct.tsx
+++ b/src/pages/ThemeProduct.tsx
@@ -47,7 +47,15 @@ const ThemeProduct = () => {
     setIsLoadingMore(true);
     try {
       const data = await fetchThemeProducts(Number(id), cursor, 10);
-      setProducts(prev => [...prev, ...data.list]);
+
+      setProducts(prev => {
+        const existingIds = new Set(prev.map(item => item.id));
+        const uniqueNewItems = data.list.filter(
+          item => !existingIds.has(item.id),
+        );
+        return [...prev, ...uniqueNewItems];
+      });
+
       setCursor(data.cursor);
       setHasMore(data.hasMoreList);
     } catch {


### PR DESCRIPTION
안녕하세요 멘토님!  
경북대 FE 최지원입니다 😊

이번 PR에서는 **Step3 과제의 요구사항 중 "기존에 작성했던 API를 React Query를 이용해 리팩터링(GET, POST 포함)"** 하는 작업을 중점적으로 수행하였으며,  
이 과정에서 **컴포넌트 구조 개선, API 호출 방식 일원화, 에러 및 로딩 처리 개선** 등을 함께 진행했습니다.

---

## API 전반 리팩터링 (React Query 기반)

### 리팩터링 목표
- **React Query 기반으로 API를 useQuery/useMutation 훅으로 통합**
- **로딩/에러 처리 일관화**, **토큰 인증 예외 처리**, **성공 이후 동작 분리**

### 적용한 주요 리팩터링 항목

| API | 구현 훅 | 적용 컴포넌트 |
|-----|---------|----------------|
| `/api/themes` | `useThemes` | `CategorySection`  
| `/api/products/ranking` | `useRanking` | `RankingSection`  
| `/api/products/:id/summary` | `useProductSummary` | `OrderPage`  
| `/api/order` | `useCreateOrder` | `OrderPage`  
| `/api/login` | `useLogin` | `LoginForm`  

---

## Suspense 처리 관련 이슈 및 해결
- 리팩터링 중 `useQuery`에서 `suspense: true` 옵션을 사용하려 했으나,  
  `useQuery`에 `suspense: true`를 넣자 TS 에러가 발생했습니다.
    (  > "개체 리터럴은 알려진 속성만 지정할 수 있습니다. 'suspense'는 'UndefinedInitialDataOptions'에 없습니다." )
- 알아보니, React Query **v5 이상에서는 suspense가 쿼리 옵션에서 제거**되고  
  대신 `QueryClient`의 `defaultOptions.queries.suspense = true` 또는  `React.Suspense` 컴포넌트로 감싸는 방식이 있어
- `useQuery`에서는 `suspense` 옵션을 제거하고  
-  대신 **컴포넌트 쪽에서 `<Suspense fallback={<Spinner />}>`**, `<ErrorBoundary>`로 감쌌습니다.
혹시 다른 관점에서 더 나은 구조가 있다면 피드백 부탁드립니다!

---
이번 과제에서
React Query의 최신 사용 방식에 따라 전반적인 API 호출 구조를 개선하고, 
컴포넌트-로직 분리를 통해 재사용성과 응집력을 높이기 위해 노력하였습니다!
또한, 기능 단위로 커밋을 나누고, 가독성과 유지보수성을 고려해 작업했습니다.

감사합니다!
리뷰 잘 부탁드립니다 🙇‍♀️
