### PR TITLE
경북대 FE 김지훈 - 1단계 React Query 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@hookform/resolvers": "^5.1.1",
+        "@tanstack/react-query": "^5.83.0",
         "axios": "^1.10.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1531,6 +1532,32 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.0.tgz",
+      "integrity": "sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.83.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.83.0.tgz",
+      "integrity": "sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^5.1.1",
+    "@tanstack/react-query": "^5.83.0",
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -1,10 +1,8 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
-import { fetchThemes } from '@/api/theme';
-import type { Theme } from '@/types/theme';
 import Spinner from '@/components/Spinner';
 import { ROUTE } from '@/constants/routes';
 import { useNavigate } from 'react-router-dom';
+import { useThemes } from '@/hooks/useTheme';
 
 const SectionWrapper = styled.section`
   padding: ${({ theme }) => theme.spacing.spacing4};
@@ -51,30 +49,13 @@ const Label = styled.div`
 `;
 
 const CategorySection = () => {
-  const [themes, setThemes] = useState<Theme[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
   const navigate = useNavigate();
+  const { data: themes, isLoading, isError } = useThemes();
 
-  useEffect(() => {
-    const loadThemes = async () => {
-      try {
-        const data = await fetchThemes();
-        setThemes(data);
-      } catch {
-        setError(true);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadThemes();
-  }, []);
-
-  if (loading) {
+  if (isLoading) {
     return <Spinner />;
   }
-  if (error || themes.length === 0) {
+  if (isError || !themes || themes.length === 0) {
     return null;
   }
 

--- a/src/components/RankingSection.tsx
+++ b/src/components/RankingSection.tsx
@@ -1,11 +1,10 @@
 import styled from '@emotion/styled';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { ROUTE } from '@/constants/routes';
 import { useUser } from '@/contexts/UserContext';
-import { fetchProductRanking } from '@/api/product';
-import type { Product } from '@/types/product';
 import Spinner from '@/components/Spinner';
+import { useProductRanking } from '@/hooks/useProduct';
 
 const genderTabs = ['전체', '여성이', '남성이', '청소년이'] as const;
 type GenderType = (typeof genderTabs)[number];
@@ -157,13 +156,16 @@ const RankingSection = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedGender = (searchParams.get('gender') as GenderType) || '전체';
   const selectedRank = (searchParams.get('rank') as keyof typeof RANK_MAP) || '많이 선물한';
-  const [productList, setProductList] = useState<Product[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
 
   const navigate = useNavigate();
   const { user } = useUser();
+
+  const {
+    data: productList = [],
+    isLoading,
+    isError,
+  } = useProductRanking(GENDER_MAP[selectedGender], RANK_MAP[selectedRank]);
 
   const handleToggle = () => {
     setIsExpanded((prev) => !prev);
@@ -188,23 +190,6 @@ const RankingSection = () => {
   };
 
   const visibleCount = isExpanded ? productList.length : INIT_COUNT;
-
-  useEffect(() => {
-    const loadRanking = async () => {
-      setLoading(true);
-      setError(false);
-      try {
-        const data = await fetchProductRanking(GENDER_MAP[selectedGender], RANK_MAP[selectedRank]);
-        setProductList(data);
-      } catch {
-        setError(true);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadRanking();
-  }, [selectedGender, selectedRank]);
 
   return (
     <SectionWrapper>
@@ -235,9 +220,9 @@ const RankingSection = () => {
         ))}
       </TrendGroupTab>
 
-      {loading ? (
+      {isLoading ? (
         <Spinner />
-      ) : error || productList.length === 0 ? (
+      ) : isError || productList.length === 0 ? (
         <EmptyProduct>상품이 없습니다.</EmptyProduct>
       ) : (
         <>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { loginRequest } from '@/api/auth';
+
+export const useLoginMutation = () => {
+  return useMutation({
+    mutationFn: loginRequest,
+  });
+};

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { postOrder } from '@/api/order';
+
+export const useOrderMutation = () => {
+  return useMutation({
+    mutationFn: postOrder,
+  });
+};

--- a/src/hooks/useProduct.ts
+++ b/src/hooks/useProduct.ts
@@ -1,0 +1,30 @@
+import { useQuery, useInfiniteQuery } from '@tanstack/react-query';
+import { fetchProductRanking, fetchProductSummary, fetchThemeProducts } from '@/api/product';
+
+export const useProductRanking = (targetType: string, rankType: string) => {
+  return useQuery({
+    queryKey: ['productRanking', targetType, rankType],
+    queryFn: () => fetchProductRanking(targetType, rankType),
+    staleTime: 1000 * 60 * 3,
+  });
+};
+
+export const useProductSummary = (productId: number) => {
+  return useQuery({
+    queryKey: ['productSummary', productId],
+    queryFn: () => fetchProductSummary(productId),
+    enabled: !!productId,
+    staleTime: 1000 * 60 * 3,
+  });
+};
+
+export const useThemeProductsInfinite = (themeId: number, limit = 20) => {
+  return useInfiniteQuery({
+    queryKey: ['themeProducts', themeId],
+    queryFn: ({ pageParam = 0 }) => fetchThemeProducts({ themeId, cursor: pageParam, limit }),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => (lastPage.hasMoreList ? lastPage.cursor : undefined),
+    enabled: !!themeId,
+    staleTime: 1000 * 60 * 3,
+  });
+};

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchThemes, fetchThemeDetail } from '@/api/theme';
+
+export const useThemes = () => {
+  return useQuery({
+    queryKey: ['themes'],
+    queryFn: fetchThemes,
+    staleTime: 1000 * 60 * 3,
+  });
+};
+
+export const useThemeDetail = (themeId: number) => {
+  return useQuery({
+    queryKey: ['themeDetail', themeId],
+    queryFn: () => fetchThemeDetail(themeId),
+    enabled: !!themeId,
+    staleTime: 1000 * 60 * 3,
+  });
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,12 +4,17 @@ import App from './App.tsx';
 import { GlobalStyle } from './styles/GlobalStyle';
 import { ThemeProvider } from '@emotion/react';
 import theme from './styles/theme';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <App />
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <App />
+      </ThemeProvider>
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -7,8 +7,8 @@ import { ROUTE } from '@/constants/routes';
 import { useForm } from 'react-hook-form';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { loginRequest } from '@/api/auth';
 import { AxiosError } from 'axios';
+import { useLoginMutation } from '@/hooks/useAuth';
 
 const Wrapper = styled.section`
   display: flex;
@@ -89,9 +89,11 @@ const LoginPage = () => {
     reValidateMode: 'onChange',
   });
 
+  const { mutateAsync: loginMutate } = useLoginMutation();
+
   const onSubmit = async ({ email, password }: FormValues) => {
     try {
-      const data = await loginRequest({ email, password });
+      const data = await loginMutate({ email, password });
       login(data);
 
       const from = location.state?.from?.pathname || ROUTE.MAIN;

--- a/src/pages/OrderPage.tsx
+++ b/src/pages/OrderPage.tsx
@@ -8,13 +8,12 @@ import { ROUTE } from '@/constants/routes';
 import { useForm } from 'react-hook-form';
 import RecipientModal, { type Recipient } from '@/components/RecipientModal';
 import { zIndex } from '@/constants/zIndex';
-import { fetchProductSummary } from '@/api/product';
-import type { ProductSummary } from '@/types/product';
-import { postOrder } from '@/api/order';
 import type { OrderRequest } from '@/types/order';
 import { useUser } from '@/contexts/UserContext';
 import { toast, ToastContainer } from 'react-toastify';
 import axios, { HttpStatusCode } from 'axios';
+import { useProductSummary } from '@/hooks/useProduct';
+import { useOrderMutation } from '@/hooks/useOrder';
 
 const Wrapper = styled.div`
   padding: ${({ theme }) => theme.spacing.spacing4};
@@ -155,30 +154,18 @@ const OrderPage = () => {
   const navigate = useNavigate();
   const { user } = useUser();
 
-  const [product, setProduct] = useState<ProductSummary | null>(null);
   const [selectedCardId, setSelectedCardId] = useState(messageCardMockData[0].id);
   const selectedCard = messageCardMockData.find((c) => c.id === selectedCardId);
   const [recipients, setRecipients] = useState<Recipient[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  useEffect(() => {
-    const loadProduct = async () => {
-      try {
-        if (!productId) return;
-        const data = await fetchProductSummary(Number(productId));
-        setProduct(data);
-      } catch (error) {
-        if (error instanceof axios.AxiosError) {
-          const msg = error.response?.data?.data?.message || '상품 정보를 불러올 수 없습니다.';
-          toast.error(msg);
-        } else {
-          toast.error('오류가 발생했습니다.');
-        }
-        navigate(ROUTE.MAIN);
-      }
-    };
-    loadProduct();
-  }, [productId, navigate]);
+  const {
+    data: product,
+    isLoading: isProductLoading,
+    isError: isProductError,
+  } = useProductSummary(Number(productId));
+
+  const { mutateAsync: orderMutate } = useOrderMutation();
 
   const {
     register,
@@ -195,13 +182,22 @@ const OrderPage = () => {
   });
 
   useEffect(() => {
+    if (isProductError) {
+      toast.error('상품 정보를 불러올 수 없습니다.');
+      navigate(ROUTE.MAIN);
+    }
+  }, [isProductError, navigate]);
+
+  useEffect(() => {
     if (user?.name) {
       setValue('sender', user.name);
     }
   }, [user, setValue]);
 
   const onSubmit = async (form: FormValues) => {
-    if (!product) return;
+    if (!product) {
+      return;
+    }
 
     if (recipients.length === 0) {
       toast.error('받는 사람이 없습니다.');
@@ -216,20 +212,20 @@ const OrderPage = () => {
         `메시지: ${form.message}`
     );
 
-    try {
-      const payload: OrderRequest = {
-        productId: product.id,
-        message: form.message,
-        messageCardId: String(selectedCardId),
-        ordererName: form.sender,
-        receivers: recipients.map((r) => ({
-          name: r.name,
-          phoneNumber: r.phone,
-          quantity: r.quantity,
-        })),
-      };
+    const payload: OrderRequest = {
+      productId: product.id,
+      message: form.message,
+      messageCardId: String(selectedCardId),
+      ordererName: form.sender,
+      receivers: recipients.map((r) => ({
+        name: r.name,
+        phoneNumber: r.phone,
+        quantity: r.quantity,
+      })),
+    };
 
-      await postOrder(payload);
+    try {
+      await orderMutate(payload);
       navigate(ROUTE.MAIN);
     } catch (error) {
       if (error instanceof axios.AxiosError) {
@@ -247,7 +243,7 @@ const OrderPage = () => {
     }
   };
 
-  if (!product) {
+  if (isProductLoading || !product) {
     return <div>상품을 찾을 수 없습니다.</div>;
   }
 

--- a/src/pages/ThemeProductsPage.tsx
+++ b/src/pages/ThemeProductsPage.tsx
@@ -1,14 +1,11 @@
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from '@emotion/styled';
-import { fetchThemeDetail } from '@/api/theme';
-import { fetchThemeProducts } from '@/api/product';
-import type { Theme } from '@/types/theme';
-import type { Product } from '@/types/product';
 import { ROUTE } from '@/constants/routes';
-import axios, { HttpStatusCode } from 'axios';
-import { toast } from 'react-toastify';
 import Spinner from '@/components/Spinner';
+import { useThemeDetail } from '@/hooks/useTheme';
+import { useThemeProductsInfinite } from '@/hooks/useProduct';
+import { toast } from 'react-toastify';
 
 const Hero = styled.section<{ bgColor: string }>`
   background-color: ${({ bgColor }) => bgColor};
@@ -78,93 +75,44 @@ const EmptyMessage = styled.div`
 
 const ThemeProductsPage = () => {
   const { themeId } = useParams<{ themeId: string }>();
-  const [theme, setTheme] = useState<Theme | null>(null);
   const navigate = useNavigate();
 
-  const [products, setProducts] = useState<Product[]>([]);
-  const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(false);
-  const observerRef = useRef<HTMLDivElement | null>(null);
-  const cursorRef = useRef(0);
-  const loadingRef = useRef(false);
+  const {
+    data: theme,
+    isLoading: isThemeLoading,
+    isError: isThemeError,
+  } = useThemeDetail(Number(themeId));
 
-  const LIMIT = 20;
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isProductLoading,
+    isError: isProductError,
+  } = useThemeProductsInfinite(Number(themeId));
 
   useEffect(() => {
-    const loadTheme = async () => {
-      try {
-        if (!themeId) {
-          return;
-        }
-        const data = await fetchThemeDetail(Number(themeId));
-        setTheme(data);
-      } catch (error) {
-        if (error instanceof axios.AxiosError) {
-          const status = error.response?.status;
-          const msg = error.response?.data?.data?.message || '테마 정보를 불러오지 못했습니다.';
-
-          if (status === HttpStatusCode.NotFound) {
-            navigate(ROUTE.MAIN);
-          } else {
-            toast.error(msg);
-          }
-        } else {
-          toast.error('오류가 발생했습니다.');
-        }
-      }
-    };
-
-    loadTheme();
-  }, [themeId, navigate]);
-
-  const loadProducts = async () => {
-    if (!themeId || loadingRef.current || !hasMore) {
-      return;
+    if (isThemeError) {
+      toast.error('테마 정보를 불러오지 못했습니다.');
+      navigate(ROUTE.MAIN);
     }
+  }, [isThemeError, navigate]);
 
-    loadingRef.current = true;
-    setLoading(true);
-    try {
-      const res = await fetchThemeProducts({
-        themeId: Number(themeId),
-        cursor: cursorRef.current,
-        limit: LIMIT,
-      });
-
-      const seen = new Set(products.map((p) => p.id));
-      const newItems = res.list.filter((item) => !seen.has(item.id));
-
-      setProducts((prev) => [...prev, ...newItems]);
-      cursorRef.current = res.cursor;
-      setHasMore(res.hasMoreList);
-    } catch {
+  useEffect(() => {
+    if (isProductError) {
       toast.error('상품 정보를 불러오지 못했습니다.');
-    } finally {
-      setLoading(false);
-      loadingRef.current = false;
     }
-  };
+  }, [isProductError]);
 
-  useEffect(() => {
-    if (!themeId) {
-      return;
-    }
-    setProducts([]);
-    cursorRef.current = 0;
-    setHasMore(true);
-    loadingRef.current = false;
-
-    setTimeout(() => {
-      loadProducts();
-    }, 0);
-  }, [themeId]);
+  const observerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         const first = entries[0];
-        if (first.isIntersecting && hasMore && !loading) {
-          loadProducts();
+        if (first.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
         }
       },
       {
@@ -173,16 +121,24 @@ const ThemeProductsPage = () => {
     );
 
     const current = observerRef.current;
-    if (current) observer.observe(current);
+    if (current) {
+      observer.observe(current);
+    }
 
     return () => {
       if (current) observer.unobserve(current);
     };
-  }, [hasMore, loading]);
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (!themeId || isThemeLoading || isProductLoading) {
+    return <Spinner />;
+  }
 
   if (!theme) {
     return null;
   }
+
+  const products = data?.pages.flatMap((page) => page.list) ?? [];
 
   return (
     <>
@@ -192,7 +148,7 @@ const ThemeProductsPage = () => {
         <Description>{theme.description}</Description>
       </Hero>
 
-      {products.length === 0 && !loading ? (
+      {products.length === 0 ? (
         <EmptyMessage>상품이 없습니다.</EmptyMessage>
       ) : (
         <>
@@ -208,7 +164,7 @@ const ThemeProductsPage = () => {
           </ProductGrid>
 
           <div ref={observerRef} style={{ height: '1px' }} />
-          {loading && <Spinner />}
+          {isFetchingNextPage && <Spinner />}
         </>
       )}
     </>


### PR DESCRIPTION
chore : React Query 라이브러리 추가
refactor : QueryClientProvider 적용
refactor : useLoginMutation 훅 사용하여 LoginPage React Query 적용 및 로그인 API 리팩토링
refactor : useOrderMutation, useProductSummary 훅 사용하여 OrderPage React Query 적용 및 주문 API 리팩토링
refactor : useThemeDetail, useThemeProductsInfinite훅 사용하여 ThemeProductsPage에 React Query 적용 및 무한스크롤 개선
refactor : Theme 목록 API를 React Query를 이용하여 정리
refactor : RankingSection React Query 적용

안녕하세요 멘토님! 이번 1단계 기존 코드에서 React Query 적용하여 리팩토링 후 PR드립니다.
이번 미션 구현에 대해 간략히 설명드리자면,
1. 기존의 useEffect와 useState로 관리하던 비동기 API 호출 로직을 React Query 기반으로 리팩토링했습니다.
- (loading, error 등을 React Query의 isLoading, isError 등으로 대체)
2. 기능별로 커스텀 훅을 만들어 API 호출 인터페이스를 심플하게 하고, 유지보수가 원활하도록 했습니다.
- (페이지/컴포넌트 별로 적용)

마지막으로 직전 단계에서 API 호출을 매번 하는 것을 보고 리소스가 낭비된다고 생각했었는데, React Query를 사용해서 3분동안 캐시된 데이터를 재사용하게 했습니다.
혹시나 더 효율적으로 코드를 개선할 수 있는 방향이 있을지 궁금합니다.

바쁘신 와중에도 불구하고 소중한 시간내서 코드리뷰 해주셔서 감사합니다!

p.s 제가 브랜치를 step2로 잘못 만드는 바람에 다음 번에 미션할때 수정하도록 하겠습니다...